### PR TITLE
rusefi/rusefi_documentation #213 #214

### DIFF
--- a/www/css/custom.css
+++ b/www/css/custom.css
@@ -14,7 +14,7 @@ html {
     background-repeat: no-repeat;
     /* padding-top: 6rem; */
     padding-top: 40vh;
-    height: 60vh;
+    height: calc(60vh - 5.5rem);
     text-align: center; }
   .value-prop {
     margin-top: 1rem; }
@@ -223,7 +223,7 @@ html {
     padding-top: 85vh;
     top: 50%;
     left: 50%;
-    transform: translate(-50%,-50%);
+    transform: translate(-50%,-55%);
   }
   .arrow span {
       display: block;
@@ -471,6 +471,10 @@ html {
     .container {
       overflow-y: visible;
     }
+    /* Arrow */
+    .arrow {
+      transform: translate(-50%, -52%);
+    }
     /* Navbar */
     .nav-container {
       overflow-y: visible;
@@ -520,7 +524,7 @@ html {
       letter-spacing: .2rem;
       margin-right: 35px;
       text-decoration: none;
-      line-height: 6.5rem;
+      line-height: 5.5rem;
       color: #222; }
     .navbar-link.active {
       color: #33C3F0; }
@@ -535,10 +539,6 @@ html {
       width: 80%; }
   
     /* Popover */
-    .popover.open {
-      display: block;
-      white-space: nowrap;
-    }
     .popover {
       display: none;
       position: absolute;
@@ -547,13 +547,22 @@ html {
       background: #fff;
       /* border: 1px solid #eee; */
       border-radius: 4px;
+      -webkit-filter: drop-shadow(0 0 6px rgba(0,0,0,.3));
+         -moz-filter: drop-shadow(0 0 6px rgba(0,0,0,.3));
+              filter: drop-shadow(0 0 6px rgba(0,0,0,.3f)); }
+    .popover.open {
+      display: block;
+      white-space: nowrap; }
+    .popover.open-bottom {
       top: 92%;
-      left: -25%;
-      -webkit-filter: drop-shadow(0 0 6px rgba(0,0,0,.1));
-         -moz-filter: drop-shadow(0 0 6px rgba(0,0,0,.1));
-              filter: drop-shadow(0 0 6px rgba(0,0,0,.1)); }
-    .popover-item:first-child .popover-link:after, 
-    .popover-item:first-child .popover-link:before {
+      left: -25%; }
+    .popover.open-top {
+      top: -122%;
+      left: -25%; }
+    .popover.open-bottom .popover-item:first-child .popover-link:after, 
+    .popover.open-bottom .popover-item:first-child .popover-link:before,
+    .popover.open-top .popover-item:last-child .popover-link:after, 
+    .popover.open-top .popover-item:last-child .popover-link:before {
       bottom: 100%;
       left: 50%;
       border: solid transparent;
@@ -562,16 +571,27 @@ html {
       width: 0;
       position: absolute;
       pointer-events: none; }
-    .popover-item:first-child .popover-link:after {
+    .popover.open-bottom .popover-item:first-child .popover-link:after,
+    .popover.open-top .popover-item:last-child .popover-link:after {
       border-color: rgba(255, 255, 255, 0);
       border-bottom-color: #fff;
       border-width: 10px;
       margin-left: -10px; }
-    .popover-item:first-child .popover-link:before {
+    .popover.open-bottom .popover-item:first-child .popover-link:before,
+    .popover.open-top .popover-item:last-child .popover-link:before {
       border-color: rgba(238, 238, 238, 0);
       border-bottom-color: #eee;
       border-width: 11px;
       margin-left: -11px; }
+    .popover.open-bottom .popover-item:first-child .popover-link:after, 
+    .popover.open-bottom .popover-item:first-child .popover-link:before {
+      bottom: 100%;
+      left: 50%; }
+    .popover.open-top .popover-item:last-child .popover-link:after, 
+    .popover.open-top .popover-item:last-child .popover-link:before {
+      top: 100%;
+      left: 50%;
+      transform: scale(-1); }
     .popover-list {
       padding: 0;
       margin: 0;
@@ -600,7 +620,8 @@ html {
       color: #fff;
       background: #f15a24; }
     .popover-link:hover,
-    .popover-item:first-child .popover-link:hover:after {
+    .popover.open-bottom .popover-item:first-child .popover-link:hover:after,
+    .popover.open-top .popover-item:last-child .popover-link:hover:after {
       border-bottom-color: #f15a24; }
     .mre-left {
       display: table-cell;

--- a/www/css/custom.css
+++ b/www/css/custom.css
@@ -498,9 +498,10 @@ html {
     .navbar,
     .navbar-spacer {
       display: block;
+      box-shadow: 0 0 0.3rem rgba(0,0,0,0.3);
       width: 100%;
       height: 5.5rem;
-      background: #fff;
+      background: #eee;
       z-index: 99;
       position: absolute;
       /* border-top: 1px solid #eee;

--- a/www/css/custom.css
+++ b/www/css/custom.css
@@ -557,7 +557,8 @@ html {
       top: 92%;
       left: -25%; }
     .popover.open-top {
-      top: -122%;
+      transform: translate(0, -100%); 
+      top: -5%;
       left: -25%; }
     .popover.open-bottom .popover-item:first-child .popover-link:after, 
     .popover.open-bottom .popover-item:first-child .popover-link:before,

--- a/www/index.html
+++ b/www/index.html
@@ -130,7 +130,7 @@
           <div id="docNavPopover" class="popover">
             <ul class="popover-list">
               <li class="popover-item">
-                <a class="popover-link" href="https://wiki.rusefi.com/">Wiki</a>
+                <a class="popover-link" target="#" href="https://wiki.rusefi.com/">Wiki</a>
               </li>
               <li class="popover-item">
                 <a class="popover-link" href="https://github.com/rusefi/rusefi/wiki/microRusEFI-Manual">microRusEFI</a>
@@ -144,19 +144,18 @@
             </ul>
           </div>
         </li>
+        <li class="navbar-item"><a class="navbar-link" target="#" href="http://www.rusefi.com/forum">Forum</a></li>
+        <li class="navbar-item">
         <li class="navbar-item"><a class="navbar-link" href="index.html#shop">Shop</a></li>
         <li class="navbar-item">
           <a class="navbar-link" href="#" data-popover="#linksNavPopover">More</a>
           <div id="linksNavPopover" class="popover">
             <ul class="popover-list">
               <li class="popover-item">
-                <a class="popover-link" href="http://www.rusefi.com/online">rusEFI online</a>
+                <a class="popover-link" target="#" href="http://www.rusefi.com/online">rusEFI online</a>
               </li>
               <li class="popover-item">
-                <a class="popover-link" href="http://www.rusefi.com/forum">Forum</a>
-              </li>
-              <li class="popover-item">
-                <a class="popover-link" href="https://wiki.rusefi.com/">Wiki</a>
+                <a class="popover-link" target="#" href="https://wiki.rusefi.com/">Wiki</a>
               </li>
             </ul>
           </div>

--- a/www/js/site.js
+++ b/www/js/site.js
@@ -80,7 +80,6 @@ $(document).ready(function() {
       } else {
         popover.toggleClass("open-bottom");
       }
-      console.log(distFromBottom);
       e.stopImmediatePropagation();
     }
   

--- a/www/js/site.js
+++ b/www/js/site.js
@@ -73,17 +73,12 @@ $(document).ready(function() {
       closePopover();
       var popover = $($(this).data('popover'));
       popover.toggleClass('open')
-      console.log(window.scrollY, window.innerHeight, popover.offset().top);
       var distFromBottom =
         window.innerHeight - popover.offset().top + window.scrollY;
       if (distFromBottom < popover.height() + 20) {
-        // Open above
-        console.log("Opening above")
-      popover.toggleClass("open-top");
+        popover.toggleClass("open-top");
       } else {
-        // Open below
-        console.log("Opening below");
-      popover.toggleClass("open-bottom");
+        popover.toggleClass("open-bottom");
       }
       console.log(distFromBottom);
       e.stopImmediatePropagation();

--- a/www/js/site.js
+++ b/www/js/site.js
@@ -73,12 +73,27 @@ $(document).ready(function() {
       closePopover();
       var popover = $($(this).data('popover'));
       popover.toggleClass('open')
+      console.log(window.scrollY, window.innerHeight, popover.offset().top);
+      var distFromBottom =
+        window.innerHeight - popover.offset().top + window.scrollY;
+      if (distFromBottom < popover.height() + 20) {
+        // Open above
+        console.log("Opening above")
+      popover.toggleClass("open-top");
+      } else {
+        // Open below
+        console.log("Opening below");
+      popover.toggleClass("open-bottom");
+      }
+      console.log(distFromBottom);
       e.stopImmediatePropagation();
     }
   
     function closePopover(e) {
       if($('.popover.open').length > 0) {
         $('.popover').removeClass('open')
+        $(".popover").removeClass("open-top");
+        $(".popover").removeClass("open-bottom");
       }
     }
   


### PR DESCRIPTION
Addresses requests for rusefi_documentation issues [#213](https://github.com/rusefi/rusefi_documentation/issues/213) and [#214](https://github.com/rusefi/rusefi_documentation/issues/214)

Update allows for navbar to be shown at bottom of landing page for displays > 1024px. Popover is adjusted to show above link when navbar is close to bottom of page. Forum link has been removed from 'More' menu to primary nav. Links leading to external sites now open in new tab instead of navigating user away from rusefi site.