### PR TITLE
Make feature table match wiki

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -318,7 +318,7 @@
           </tr>
           <tr>
             <td class="evenrow"><a href="https://wiki.rusefi.com/Rotary">Rotary Engines</a></td>
-            <td class="evenrow"><i class="fa fa-check-circle-o fa-2x" aria-hidden="true"></i></td>
+            <td class="evenrow"><i class="fa fa-check-circle-o fa-2x" aria-hidden="true" style="color:rgba(0, 0, 0, 0.3);"></i></td>
           </tr>
           <tr>
             <td class="oddrow"><a href="https://wiki.rusefi.com/TCU-status">Automatic Transmission Control</a></td>


### PR DESCRIPTION
It matches the wiki now, except that I manually applied the "fade" to the Rotary check mark.